### PR TITLE
Added link to Tag Bubbles app

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -1,5 +1,12 @@
 [
   {
+    "name": "Tag bubbles",
+    "previewImageUrl": "data/images/tag-bubbles.png",
+    "primaryUrl": "http://niksilver.github.io/elm-tag-bubbles/",
+    "repositoryUrl": "https://github.com/niksilver/elm-tag-bubbles",
+    "description": "Exploring relationships between topics written about at theguardian.com"
+  },
+  {
     "name": "Pattern Editor",
     "previewImageUrl": "data/images/pattern.png",
     "primaryUrl": "http://eskimoblood.github.io/elm-wallpaper-editor/",


### PR DESCRIPTION
A new application for the Elm showcase, detailed in projects.json. Application allows the user to explore and visualise the relationships between topics in the news.