### PR TITLE
blur the active button after page change

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
     app.ports.notifyOffsetChangedRaw.subscribe(function () {
       setTimeout(function () {
         window.scrollTo(0, 0);
+        if (document.activeElement) {
+          document.activeElement.blur();
+        }
       }, 10);
     });
   </script>


### PR DESCRIPTION
At the moment pressing space after changing page changes page again (see #67). This PR removes focus from the button after a page change.